### PR TITLE
Added support for § and £ in IDs

### DIFF
--- a/src/test/java/org/rpgleparser/TestC.java
+++ b/src/test/java/org/rpgleparser/TestC.java
@@ -152,7 +152,16 @@ public class TestC {
                 "", "", "", "open", "QSYSPRT", "", "", "", "", "", "", "");
     }
 
-
+    @Test
+    public void testCSpecWithSTrangeChars() {
+        String inputString =
+                        "     C                   EVAL      §§SVAR=§§SVAR";
+        String paddedInput = TestUtils.padSourceLines(inputString, false);
+        List<String> errors = new ArrayList<String>();
+        boolean gui = false;
+		TestUtils.parseAndGetTokens(paddedInput, errors, gui);
+    }
+    
     @Test
     public void testCSpec_Comments3() {
         String inputString =

--- a/src/test/java/org/rpgleparser/utils/TestUtils.java
+++ b/src/test/java/org/rpgleparser/utils/TestUtils.java
@@ -103,7 +103,7 @@ public class TestUtils {
     	printTokens(lexer.getAllTokens());
     }
 
-    private static List<CommonToken> parseAndGetTokens(String inputString, final List<String> errors, final boolean gui) {
+    public static List<CommonToken> parseAndGetTokens(String inputString, final List<String> errors, final boolean gui) {
         final RpgParser parser = initialiseParser(inputString, errors);
 
         RpgParser.RContext parseTree = parser.r();


### PR DESCRIPTION
Changes to the lexer in order to accept  § and £ in IDs.
Added a test case.